### PR TITLE
fix(base-template): Quote boolean values for lgtm.achrovisual.io/logs annotation

### DIFF
--- a/charts/private/test-app/Chart.yaml
+++ b/charts/private/test-app/Chart.yaml
@@ -3,5 +3,5 @@ name: test-app
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.3.4
+    version: 0.3.5
     repository: https://achrovisual.github.io/hl-k3s/

--- a/charts/public/base-template/Chart.yaml
+++ b/charts/public/base-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/public/base-template/templates/deployment.yaml
+++ b/charts/public/base-template/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        lgtm.achrovisual.io/logs: {{ if .Values.monitoring.logs.enabled }}{{.Values.monitoring.logs.enabled}}{{else}}{{.Values.monitoring.enabled}}{{end}}
+        lgtm.achrovisual.io/logs: {{ if .Values.monitoring.logs.enabled }}{{ .Values.monitoring.logs.enabled | quote }}{{ else }}{{ .Values.monitoring.enabled | quote }}{{ end }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The lgtm.achrovisual.io/logs annotation in the Helm template was being assigned boolean values directly, which is incompatible with Kubernetes' requirement for string annotation values. This commit uses the `quote` function to convert boolean values to strings, resolving the "cannot unmarshal bool into Go struct field ... of type string" error encountered during Helm apply.