### PR TITLE
fix(test-app): Set log annotation via monitoring.logs.enabled

### DIFF
--- a/charts/private/test-app/values.yaml
+++ b/charts/private/test-app/values.yaml
@@ -1,3 +1,4 @@
 base-template:
   monitoring:
-    enabled: true
+    logs:
+      enabled: true


### PR DESCRIPTION
This tests the conditional for setting the log annotation. Previously, it was using `monitoring.enabled`. This PR sets the annotation via `monitoring.logs.enabled`.