### PR TITLE
fix(base-template): Use default function to set log annotation

### DIFF
--- a/charts/private/test-app/Chart.yaml
+++ b/charts/private/test-app/Chart.yaml
@@ -3,5 +3,5 @@ name: test-app
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.3.5
+    version: 0.3.6
     repository: https://achrovisual.github.io/hl-k3s/

--- a/charts/private/test-app/values.yaml
+++ b/charts/private/test-app/values.yaml
@@ -1,4 +1,0 @@
-base-template:
-  monitoring:
-    logs:
-      enabled: true

--- a/charts/public/base-template/Chart.yaml
+++ b/charts/public/base-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/public/base-template/templates/deployment.yaml
+++ b/charts/public/base-template/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        lgtm.achrovisual.io/logs: {{ if .Values.monitoring.logs.enabled }}{{ .Values.monitoring.logs.enabled | quote }}{{ else }}{{ .Values.monitoring.enabled | quote }}{{ end }}
+        lgtm.achrovisual.io/logs: {{ default false .Values.monitoring.logs.enabled | quote }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This uses the `default` flow control function to set the log annotation. It defaults to false if `monitoring.logs.enabled` is empty.