### PR TITLE
chore: portfolio - Update image tag to sha-f83eaab10bf67a636da24f8b0bdcb5d31214a2c0

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -4,7 +4,7 @@ base-template:
       enabled: true
   image:
     repository: ghcr.io/achrovisual/portfolio
-    tag: sha-c9f9258f4c4132e64f8e8f1e143a4ad0483391f2
+    tag: sha-f83eaab10bf67a636da24f8b0bdcb5d31214a2c0
     pullPolicy: IfNotPresent
   service:
     port: 3000


### PR DESCRIPTION
This PR updates the **`portfolio` Helm chart** image tag to **`sha-f83eaab10bf67a636da24f8b0bdcb5d31214a2c0`**.

**Changes:**

* Updated `private/portfolio/values.yaml`:
    ```yaml
    image:
      repository: my-company-registry/portfolio-service
      tag: sha-f83eaab10bf67a636da24f8b0bdcb5d31214a2c0 # Previously [old-tag]
    ```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image version for the portfolio service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->