### PR TITLE
feature: Add LoadBalancer service type to portfolio 

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -8,3 +8,4 @@ base-template:
     pullPolicy: IfNotPresent
   service:
     port: 3000
+    type: LoadBalancer


### PR DESCRIPTION
This PR introduces the `type: LoadBalancer` configuration to the `service` section within the `portfolio` Helm chart.

Previously, the service only specified a port. By adding the `type: LoadBalancer`, we enable the creation of an external load balancer for services deployed with this template, allowing for external access to the application. This change provides greater flexibility in how services are exposed.