### PR TITLE
feature: Add environment variable injection support

### DIFF
--- a/charts/public/base-template/Chart.yaml
+++ b/charts/public/base-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/public/base-template/templates/deployment.yaml
+++ b/charts/public/base-template/templates/deployment.yaml
@@ -45,22 +45,24 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if or .Values.env (and .Values.secretEnv .Values.secretEnv.enabled) }}
           env:
             {{- if .Values.env }}
-              {{- range $key, $value := .Values.env }}
+            {{- range $key, $value := .Values.env }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
-              {{- end }}
+            {{- end }}
             {{- end }}
             {{- if and .Values.secretEnv .Values.secretEnv.enabled }}
-              {{- range $envVarName, $secretKey := .Values.secretEnv.mappings }}
+            {{- range $envVarName, $secretKey := .Values.secretEnv.mappings }}
             - name: {{ $envVarName | quote }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretEnv.name }}
+                  name: {{ .Values.secretEnv.name | quote }}
                   key: {{ $secretKey | quote }}
-              {{- end }}
             {{- end }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/public/base-template/templates/deployment.yaml
+++ b/charts/public/base-template/templates/deployment.yaml
@@ -45,6 +45,22 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          env:
+            {{- if .Values.env }}
+              {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+              {{- end }}
+            {{- end }}
+            {{- if and .Values.secretEnv .Values.secretEnv.enabled }}
+              {{- range $envVarName, $secretKey := .Values.secretEnv.mappings }}
+            - name: {{ $envVarName | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretEnv.name }}
+                  key: {{ $secretKey | quote }}
+              {{- end }}
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This PR adds the capability to inject environment variables into application containers managed by this `base-template` chart. This includes support for both direct key-value injection and secure referencing of values from Kubernetes Secrets.

This enhancement provides greater configuration flexibility and improves security for sensitive data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring environment variables in deployments, including both plain values and secret-based values, via Helm chart values.

* **Chores**
  * Updated Helm chart version to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->