### PR TITLE
fix: Update base-template dependency

### DIFF
--- a/charts/private/portfolio/Chart.lock
+++ b/charts/private/portfolio/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: base-template
-  repository: https://achrovisual.github.io/hl-k3s/
-  version: 0.3.6
-digest: sha256:9145414a874228cdab7bff19ffb821049b99f92d492e8c36080f4af59bad0330
-generated: "2025-07-10T19:26:19.957518352+08:00"

--- a/charts/private/portfolio/Chart.yaml
+++ b/charts/private/portfolio/Chart.yaml
@@ -3,5 +3,5 @@ name: portfolio
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.3.7
+    version: 0.4.0
     repository: https://achrovisual.github.io/hl-k3s/

--- a/charts/private/test-app/Chart.yaml
+++ b/charts/private/test-app/Chart.yaml
@@ -3,5 +3,5 @@ name: test-app
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.3.6
+    version: 0.4.0
     repository: https://achrovisual.github.io/hl-k3s/


### PR DESCRIPTION
This PR updates the base-template dependency of my own charts to `0.4.0`. This also remove the lock file in the `portfolio` chart.