### PR TITLE
feature: Add OCI Helm Repository for kproximate

### DIFF
--- a/charts/private/argo-cd-setup/templates/repositories/jedrw.yaml
+++ b/charts/private/argo-cd-setup/templates/repositories/jedrw.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hl-k3s
+  namespace: argo-cd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  name: jedrw
+  url: ghcr.io/jedrw
+  enableOCI: "true"
+  type: helm


### PR DESCRIPTION
This PR introduces the necessary configuration for Argo CD to access the `kproximate` Helm chart hosted on an OCI registry.

**Key Changes:**

* **Adds OCI Repository Definition:** A new Kubernetes Secret (`jedrw.yaml`) is added to `argo-cd-setup/templates/repositories/`. This secret defines `ghcr.io/jedrw` as an OCI-enabled Helm chart repository within Argo CD. This allows future Argo CD applications to reference charts from this registry.