### PR TITLE
fix: Correct jedrw repository name

### DIFF
--- a/charts/private/argo-cd-setup/templates/repositories/jedrw.yaml
+++ b/charts/private/argo-cd-setup/templates/repositories/jedrw.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: hl-k3s
+  name: jedrw
   namespace: argo-cd
   labels:
     argocd.argoproj.io/secret-type: repository


### PR DESCRIPTION
This PR corrects the name attribute of `jedrw` from `hl-k3s` to `jedrw`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the name of a Kubernetes Secret resource in the Argo CD setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->