### PR TITLE
feature: Update base-template version

### DIFF
--- a/charts/private/portfolio/Chart.yaml
+++ b/charts/private/portfolio/Chart.yaml
@@ -3,5 +3,5 @@ name: portfolio
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.4.0
+    version: 0.4.1
     repository: https://achrovisual.github.io/hl-k3s/


### PR DESCRIPTION
This PR updates the base-template dependency of my own charts to `0.4.1`. This also remove the lock file in the portfolio chart.