### PR TITLE
chore: portfolio - Update image tag to sha-ec295c4864354ceebd3a090ff9604a185f61b428

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -4,7 +4,7 @@ base-template:
       enabled: true
   image:
     repository: ghcr.io/achrovisual/portfolio
-    tag: sha-94e186bc88cdea2cb7aa4b74e455ab621ce7476d
+    tag: sha-ec295c4864354ceebd3a090ff9604a185f61b428
     pullPolicy: IfNotPresent
   service:
     port: 3000


### PR DESCRIPTION
This PR updates the **`portfolio` Helm chart** image tag to **`sha-ec295c4864354ceebd3a090ff9604a185f61b428`**.

**Changes:**

* Updated `private/portfolio/values.yaml`:
    ```yaml
    image:
      repository: my-company-registry/portfolio-service
      tag: sha-ec295c4864354ceebd3a090ff9604a185f61b428 # Previously [old-tag]
    ```