### PR TITLE
chore: portfolio - Update image tag to sha-cd48a6964217498882a07dcf28fdcaf424e585f9

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -16,3 +16,18 @@ base-template:
       mappings:
         GH_API_TOKEN: GH_API_TOKEN
         GH_USERNAME: GH_USERNAME
+  probes:
+    enabled: true
+    liveness:
+      path: /api/status
+      initialDelaySeconds: 20
+      periodSeconds: 300
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      path: /api/status
+      port: 3000
+      initialDelaySeconds: 5
+      periodSeconds: 300
+      timeoutSeconds: 3
+      failureThreshold: 1

--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -4,7 +4,7 @@ base-template:
       enabled: true
   image:
     repository: ghcr.io/achrovisual/portfolio
-    tag: sha-ec295c4864354ceebd3a090ff9604a185f61b428
+    tag: sha-cd48a6964217498882a07dcf28fdcaf424e585f9
     pullPolicy: IfNotPresent
   service:
     port: 3000


### PR DESCRIPTION
aThis PR updates the **`portfolio` Helm chart** image tag to **`sha-cd48a6964217498882a07dcf28fdcaf424e585f9`**.

**Changes:**

* Updated `private/portfolio/values.yaml`:
    ```yaml
    image:
      repository: my-company-registry/portfolio-service
      tag: sha-cd48a6964217498882a07dcf28fdcaf424e585f9 # Previously [old-tag]
    ```