### PR TITLE
chore: Add CHANGELOG.md for chart releases

### DIFF
--- a/charts/private/portfolio/Chart.yaml
+++ b/charts/private/portfolio/Chart.yaml
@@ -3,5 +3,5 @@ name: portfolio
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.4.1
+    version: 0.4.2
     repository: https://achrovisual.github.io/hl-k3s/

--- a/charts/private/test-app/Chart.yaml
+++ b/charts/private/test-app/Chart.yaml
@@ -3,5 +3,5 @@ name: test-app
 version: 0.1.0
 dependencies:
   - name: base-template
-    version: 0.4.0
+    version: 0.4.2
     repository: https://achrovisual.github.io/hl-k3s/

--- a/charts/public/base-template/CHANGELOG.md
+++ b/charts/public/base-template/CHANGELOG.md
@@ -1,0 +1,26 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.2] - 2025-07-20
+
+### Added
+
+-   Initial implementation of the `CHANGELOG.md` file.
+
+## [0.4.1] - 2025-07-17
+
+### Fixed
+
+-   Corrected Helm subchart environment variable injection path.
+-   Fixed the guard so it only renders when at least one variable is emitted.
+
+## [0.4.0] - 2025-07-11
+
+### Added
+
+-   Implemented dynamic environment variable injection into containers.
+-   Added support for wrapping environment variables in a block.


### PR DESCRIPTION
This PR introduces the `CHANGELOG.md` file to the `base-template` Helm chart.

The `CHANGELOG.md` will serve as a curated, human-readable record of all notable changes made to the chart, adhering to the "Keep a Changelog" format and Semantic Versioning principles.

This initial commit includes entries for versions `0.4.0`, `0.4.1`, and `0.4.2` to provide historical context for recent changes.

Future releases will be documented in this file to enhance transparency and provide clear communication about updates, fixes, and new features.