### PR TITLE
chore: Update base-template chart version to 0.4.2

### DIFF
--- a/charts/public/base-template/Chart.yaml
+++ b/charts/public/base-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This PR updates the base-template chart version to `0.4.2` to generate a new release.