### PR TITLE
chore: Automate Helm chart release notes using CHANGELOG.md

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Get Chart Version from Chart.yaml
         id: get_chart_version
         run: |
-          CHART_VERSION=$(grep "version:" charts/public/base-template/Chart.yaml | awk '{print $2}')
+          CHART_VERSION=$(grep '^\s*version:' charts/public/base-template/Chart.yaml | awk '{print $2}')
           echo "Detected chart version: $CHART_VERSION"
           echo "CHART_VERSION=$CHART_VERSION" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -51,7 +51,7 @@ jobs:
         id: extract_changelog
         run: |
           CHANGELOG_FILE="charts/public/base-template/CHANGELOG.md"
-          
+
           if [ ! -f "$CHANGELOG_FILE" ]; then
             echo "::error file=$CHANGELOG_FILE::CHANGELOG.md not found at $CHANGELOG_FILE"
             exit 1

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -40,13 +40,52 @@ jobs:
       - name: Set Target Chart Environment Variable
         run: echo "TARGET_CHARTS=base-template" >> "$GITHUB_ENV"
 
+      - name: Get Chart Version from Chart.yaml
+        id: get_chart_version
+        run: |
+          CHART_VERSION=$(grep "version:" charts/public/base-template/Chart.yaml | awk '{print $2}')
+          echo "Detected chart version: $CHART_VERSION"
+          echo "CHART_VERSION=$CHART_VERSION" >> "$GITHUB_ENV"
+
+      - name: Extract Changelog Content for Current Version
+        id: extract_changelog
+        run: |
+          CHANGELOG_FILE="charts/public/base-template/CHANGELOG.md"
+          
+          if [ ! -f "$CHANGELOG_FILE" ]; then
+            echo "::error file=$CHANGELOG_FILE::CHANGELOG.md not found at $CHANGELOG_FILE"
+            exit 1
+          fi
+
+          CHANGELOG_CONTENT=$(awk -v version="${{ env.CHART_VERSION }}" '
+            /^## \[/ {
+              if (found_version) { exit }
+              if ($0 ~ "## \\[" version "\\]") {
+                found_version = 1
+                next
+              }
+            }
+            found_version { print }
+          ' "$CHANGELOG_FILE")
+
+          CHANGELOG_CONTENT=$(echo "$CHANGELOG_CONTENT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            echo "::warning::No specific changelog content found for version ${{ env.CHART_VERSION }} in $CHANGELOG_FILE. Using a fallback message."
+            echo "release_notes=Release of chart version ${{ env.CHART_VERSION }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "$CHANGELOG_CONTENT" > release_notes.txt
+            echo "release_notes_file=release_notes.txt" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Chart Releaser Action
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts/public
+          release_notes: ${{ steps.extract_changelog.outputs.release_notes }}
+          release_notes_file: ${{ steps.extract_changelog.outputs.release_notes_file }}
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_GENERATE_RELEASE_NOTES: true
 
       - name: Login to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3


### PR DESCRIPTION
This Pull Request updates the Helm chart release workflow to automatically generate GitHub Release notes from the `CHANGELOG.md` file.

Previously, release notes were auto-generated from commit messages. This change ensures that the curated, human-readable content from `CHANGELOG.md` is used as the primary source for release descriptions, providing more consistent and detailed information to users.

Key changes in the workflow:
- A new step to extract the chart version from `Chart.yaml`.
- A new step to parse the `CHANGELOG.md` file and extract the relevant content for the current release version.
- The extracted content is then passed to the `helm/chart-releaser-action` as `release_notes`.

This enhancement improves transparency and maintainability of our Helm chart releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to automatically extract and include version-specific changelog entries in release notes.
  * Enhanced error handling for missing or incomplete changelog information during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->