### PR TITLE
fix: Resolve release notes input warning in Helm chart workflow

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -51,6 +51,7 @@ jobs:
         id: extract_changelog
         run: |
           CHANGELOG_FILE="charts/public/base-template/CHANGELOG.md"
+          RELEASE_NOTES_FILE="release_notes.txt"
 
           if [ ! -f "$CHANGELOG_FILE" ]; then
             echo "::error file=$CHANGELOG_FILE::CHANGELOG.md not found at $CHANGELOG_FILE"
@@ -72,20 +73,19 @@ jobs:
 
           if [ -z "$CHANGELOG_CONTENT" ]; then
             echo "::warning::No specific changelog content found for version ${{ env.CHART_VERSION }} in $CHANGELOG_FILE. Using a fallback message."
-            echo "release_notes=Release of chart version ${{ env.CHART_VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "Release of chart version ${{ env.CHART_VERSION }}" > "$RELEASE_NOTES_FILE"
           else
-            echo "$CHANGELOG_CONTENT" > release_notes.txt
-            echo "release_notes_file=release_notes.txt" >> "$GITHUB_OUTPUT"
+            echo "$CHANGELOG_CONTENT" > "$RELEASE_NOTES_FILE"
           fi
+          echo "release_notes_file=$RELEASE_NOTES_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Run Chart Releaser Action
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts/public
-          release_notes: ${{ steps.extract_changelog.outputs.release_notes }}
-          release_notes_file: ${{ steps.extract_changelog.outputs.release_notes_file }}
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NOTES_FILE: ${{ steps.extract_changelog.outputs.release_notes_file }}
 
       - name: Login to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3


### PR DESCRIPTION
This PR addresses a warning encountered with the `helm/chart-releaser-action@v1.7.0` regarding unexpected inputs for `release_notes` and `release_notes_file`.

The `chart-releaser-action` expects release notes to be provided via environment variables (`CR_RELEASE_NOTES_FILE`) rather than direct `with` inputs. This change modifies the workflow to correctly pass the path to the generated release notes file using the appropriate environment variable.

This ensures the workflow functions as intended, providing curated release notes from `CHANGELOG.md` without generating warnings.