### PR TITLE
fix: Enhance changelog extraction to support date-stamped headings

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           CHANGELOG_FILE="charts/public/base-template/CHANGELOG.md"
           RELEASE_NOTES_FILE="release_notes.txt"
-
+          
           if [ ! -f "$CHANGELOG_FILE" ]; then
             echo "::error file=$CHANGELOG_FILE::CHANGELOG.md not found at $CHANGELOG_FILE"
             exit 1
@@ -61,7 +61,7 @@ jobs:
           CHANGELOG_CONTENT=$(awk -v version="${{ env.CHART_VERSION }}" '
             /^## \[/ {
               if (found_version) { exit }
-              if ($0 ~ "## \\[" version "\\]") {
+              if ($0 ~ "^## \\[" version "\\]($| - .*)") {
                 found_version = 1
                 next
               }


### PR DESCRIPTION
This PR addresses the issue where GitHub Release notes were appearing blank due to the workflow's inability to correctly extract content from `CHANGELOG.md` for versions with date stamps in their headings (e.g., `## [0.4.2] - 2025-07-20`).

The `awk` command in the `Extract Changelog Content for Current Version` step has been updated with a more flexible regular expression. This new regex now accurately matches version headings that include an optional date, ensuring that the correct changelog content is extracted and used for GitHub Release descriptions.

This fix improves the reliability of our automated release notes generation.