### PR TITLE
fix: Use cr.yaml to pass CHANGELOG.md for chart releases

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -40,45 +40,6 @@ jobs:
       - name: Set Target Chart Environment Variable
         run: echo "TARGET_CHARTS=base-template" >> "$GITHUB_ENV"
 
-      - name: Get Chart Version from Chart.yaml
-        id: get_chart_version
-        run: |
-          CHART_VERSION=$(grep '^\s*version:' charts/public/base-template/Chart.yaml | awk '{print $2}')
-          echo "Detected chart version: $CHART_VERSION"
-          echo "CHART_VERSION=$CHART_VERSION" >> "$GITHUB_ENV"
-
-      - name: Extract Changelog Content for Current Version
-        id: extract_changelog
-        run: |
-          CHANGELOG_FILE="charts/public/base-template/CHANGELOG.md"
-          RELEASE_NOTES_FILE="release_notes.txt"
-          
-          if [ ! -f "$CHANGELOG_FILE" ]; then
-            echo "::error file=$CHANGELOG_FILE::CHANGELOG.md not found at $CHANGELOG_FILE"
-            exit 1
-          fi
-
-          CHANGELOG_CONTENT=$(awk -v version="${{ env.CHART_VERSION }}" '
-            /^## \[/ {
-              if (found_version) { exit }
-              if ($0 ~ "^## \\[" version "\\]($| - .*)") {
-                found_version = 1
-                next
-              }
-            }
-            found_version { print }
-          ' "$CHANGELOG_FILE")
-
-          CHANGELOG_CONTENT=$(echo "$CHANGELOG_CONTENT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-
-          if [ -z "$CHANGELOG_CONTENT" ]; then
-            echo "::warning::No specific changelog content found for version ${{ env.CHART_VERSION }} in $CHANGELOG_FILE. Using a fallback message."
-            echo "Release of chart version ${{ env.CHART_VERSION }}" > "$RELEASE_NOTES_FILE"
-          else
-            echo "$CHANGELOG_CONTENT" > "$RELEASE_NOTES_FILE"
-          fi
-          echo "release_notes_file=$RELEASE_NOTES_FILE" >> "$GITHUB_OUTPUT"
-
       - name: Run Chart Releaser Action
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts/public
+          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NOTES_FILE: ${{ steps.extract_changelog.outputs.release_notes_file }}

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+release-name-template: "v{{ .Version }}"
+release-notes-file: CHANGELOG.md


### PR DESCRIPTION
This PR reverts the initial implementation of `CHANGELOG.md` extraction and passes `cr.yaml` instead to the chart release step.