### PR TITLE
fix: Use default release name template

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,1 @@
-release-name-template: "v{{ .Version }}"
 release-notes-file: CHANGELOG.md


### PR DESCRIPTION
This PR removes `release-name-template` from `cr.yaml` in favor of the default naming convention.