### PR TITLE
chore: portfolio - Update image tag to sha-875f9d30d6c352be935315806bca5bc012a28986

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -4,7 +4,7 @@ base-template:
       enabled: true
   image:
     repository: ghcr.io/achrovisual/portfolio
-    tag: sha-cd48a6964217498882a07dcf28fdcaf424e585f9
+    tag: sha-875f9d30d6c352be935315806bca5bc012a28986
     pullPolicy: IfNotPresent
   service:
     port: 3000


### PR DESCRIPTION
This PR updates the **`portfolio` Helm chart** image tag to **`sha-875f9d30d6c352be935315806bca5bc012a28986`**.

**Changes:**

* Updated `private/portfolio/values.yaml`:
    ```yaml
    image:
      repository: ghcr.io/achrovisual/portfolio
      tag: sha-875f9d30d6c352be935315806bca5bc012a28986 # Previously [old-tag]
    ```