### PR TITLE
feature: Enhance CI workflow to include check for changes before releasing Helm chart

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -61,7 +61,6 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NOTES_FILE: ${{ steps.extract_changelog.outputs.release_notes_file }}
 
       - name: Login to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3


### PR DESCRIPTION
This PR introduces a key change to enhance our CI workflow by including a check to determine if there are any changes in the `charts/public` directory. If no changes are detected, the process of releasing the Helm chart will be skipped to avoid unnecessary actions. Here's what this update includes:
- Added a step in the GitHub Actions workflow that checks for modifications in the `charts/public` folder compared to the latest commit.
- Implemented conditional execution based on whether changes are detected, ensuring that the release process only proceeds if there are actual updates in the specified directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Optimized chart release pipeline to run only when chart changes are detected, preventing empty releases and reducing CI time.
  * Automatically publishes updated Helm charts to GitHub Container Registry (GHCR) for easier consumption.
  * Streamlined workflow by removing redundant registry login.
  * Enhanced logging during chart publishing for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->