### PR TITLE
chore: portfolio - Update image tag to sha-0b725e9ff1237360d37e4eb9f63b02831cb699b0

### DIFF
--- a/charts/private/portfolio/values.yaml
+++ b/charts/private/portfolio/values.yaml
@@ -5,7 +5,7 @@ base-template:
       enabled: true
   image:
     repository: ghcr.io/achrovisual/portfolio
-    tag: sha-875f9d30d6c352be935315806bca5bc012a28986
+    tag: sha-0b725e9ff1237360d37e4eb9f63b02831cb699b0
     pullPolicy: IfNotPresent
   service:
     port: 3000


### PR DESCRIPTION
This PR updates the **`portfolio` Helm chart** image tag to **`sha-0b725e9ff1237360d37e4eb9f63b02831cb699b0`**.

**Changes:**

* Updated `private/portfolio/values.yaml`:
    ```yaml
    image:
      repository: ghcr.io/achrovisual/portfolio
      tag: sha-0b725e9ff1237360d37e4eb9f63b02831cb699b0 # Previously [old-tag]
    ```