### PR TITLE
feature: Set up Penpot

### DIFF
--- a/charts/private/argo-cd-setup/templates/applications/cu/argo-cd-setup.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/cu/argo-cd-setup.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/argo-cd-setup
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: argo-cd

--- a/charts/private/argo-cd-setup/templates/applications/cu/argo-cd.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/cu/argo-cd.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/argo-cd
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: argo-cd

--- a/charts/private/argo-cd-setup/templates/applications/cu/cert-manager.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/cu/cert-manager.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/cert-manager
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager

--- a/charts/private/argo-cd-setup/templates/applications/cu/metallb.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/cu/metallb.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/metallb
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: metallb

--- a/charts/private/argo-cd-setup/templates/applications/cu/nginx.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/cu/nginx.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/nginx
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: https://kubernetes.default.svc
     namespace: nginx

--- a/charts/private/argo-cd-setup/templates/applications/dev/cert-manager.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/cert-manager.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/cert-manager
-    targetRevision: HEAD
+    targetRevision: main
     helm:
       valueFiles:
         - values.yaml

--- a/charts/private/argo-cd-setup/templates/applications/dev/metallb.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/metallb.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/metallb
-    targetRevision: HEAD
+    targetRevision: main
     helm:
       valueFiles:
         - values.yaml

--- a/charts/private/argo-cd-setup/templates/applications/dev/nginx.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/nginx.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/nginx
-    targetRevision: HEAD
+    targetRevision: main
     helm:
       valueFiles:
         - values.yaml

--- a/charts/private/argo-cd-setup/templates/applications/dev/open-webui.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/open-webui.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/open-webui
-    targetRevision: HEAD
+    targetRevision: main
   destination:
     server: {{ .Values.clusters.dev.server }}
     namespace: open-webui

--- a/charts/private/argo-cd-setup/templates/applications/dev/otel-collector.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/otel-collector.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/otel-collector
-    targetRevision: HEAD
+    targetRevision: main
     helm:
       valueFiles:
         - values.yaml

--- a/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/penpot
-    targetRevision: feature/set-up-penpot
+    targetRevision: main
   destination:
     server: {{ .Values.clusters.dev.server }}
     namespace: penpot

--- a/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: penpot-dev
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: hl-dev
+  source:
+    repoURL: https://github.com/achrovisual/hl-k3s
+    path: charts/private/penpot
+    targetRevision: HEAD
+  destination:
+    server: {{ .Values.clusters.dev.server }}
+    namespace: penpot
+  syncPolicy:
+    automated:
+      enabled: false
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 2
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/penpot.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/penpot
-    targetRevision: HEAD
+    targetRevision: feature/set-up-penpot
   destination:
     server: {{ .Values.clusters.dev.server }}
     namespace: penpot

--- a/charts/private/argo-cd-setup/templates/applications/dev/portfolio.yaml
+++ b/charts/private/argo-cd-setup/templates/applications/dev/portfolio.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     repoURL: https://github.com/achrovisual/hl-k3s
     path: charts/private/portfolio
-    targetRevision: HEAD
+    targetRevision: main
     helm:
       valueFiles:
         - values.yaml

--- a/charts/private/argo-cd-setup/templates/repositories/penpot.yaml
+++ b/charts/private/argo-cd-setup/templates/repositories/penpot.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: penpot
+  namespace: argo-cd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  url: https://helm.penpot.app/
+  name: penpot
+  type: helm

--- a/charts/private/penpot/Chart.yaml
+++ b/charts/private/penpot/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: penpot
+version: 1.0.0
+dependencies:
+  - name: penpot
+    version: 0.27.0
+    repository: https://helm.penpot.app/

--- a/charts/private/penpot/templates/_helpers.tpl
+++ b/charts/private/penpot/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+The short name of the chart.
+*/}}
+{{- define "hl-k3s.penpot.shortname" -}}
+{{- printf "%s" "penpot" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hl-k3s.penpot.fullname" -}}
+{{- printf "%s-%s" .Release.Name "penpot" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/private/penpot/templates/ingress.yaml
+++ b/charts/private/penpot/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: penpot-ingress
+  namespace: penpot
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{ toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | default "nginx" }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: penpot-tls-secret
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "hl-k3s.penpot.shortname" . }}
+                port:
+                  number: {{ $.Values.service.port }}
+{{- end -}}

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -1,3 +1,5 @@
+service:
+  port: 8080
 ingress:
   enabled: true
   annotations:

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -1,3 +1,5 @@
+penpot:
+  fullnameOverride: penpot
 service:
   port: 8080
 ingress:

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -1,0 +1,8 @@
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: lets-encrypt-prod
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  className: nginx
+  # Replace with your desired hostname
+  host: penpot.your-domain.com

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -6,6 +6,9 @@ penpot:
   config:
     # Replace with your desired hostname
     publicUri: penpot.your-domain.com
+  backend:
+    startupProbe:
+      failureThreshold: 60
 service:
   port: 8080
 ingress:

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -1,5 +1,8 @@
 penpot:
   fullnameOverride: penpot
+  config:
+    # Replace with your desired hostname
+    publicUri: penpot.your-domain.com
 service:
   port: 8080
 ingress:

--- a/charts/private/penpot/values.yaml
+++ b/charts/private/penpot/values.yaml
@@ -1,4 +1,7 @@
 penpot:
+  global:
+    postgresqlEnabled: true
+    valkeyEnabled: true
   fullnameOverride: penpot
   config:
     # Replace with your desired hostname


### PR DESCRIPTION
This PR sets up Penpot in `hl-dev` cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Penpot deployment in the dev environment managed by Argo CD and Helm.
  - Public access via HTTPS Ingress (NGINX), with TLS and configurable host.
  - Defaults enable database and cache services; service exposed on port 8080.
  - Self-healing and pruning enabled; namespace auto-creation supported.

- Chores
  - Registered Helm repository for Penpot.
  - Added base chart configuration and default values for deployment and probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->